### PR TITLE
chore: add libgit2 install steps for windows to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,33 @@ sudo pacman -S libgit2
 brew install libgit2
 ```
 
+#### Windows
+
+There are no pre-packaged releases of libgit2 on Windows so the library must be built from source.
+
+##### Install CMake and MinGW (with Chocolatey)
+
+```powershell
+#requires -RunAsAdministrator
+choco install choco install cmake --installargs 'ADD_CMAKE_TO_PATH=User'
+choco install mingw
+```
+
+Make sure to restart your terminal after installing MinGW to ensure that the `gcc` and `g++` commands are available.
+
+##### Clone and build libgit2
+
+```powershell
+git clone https://github.com/libgit2/libgit2
+cd libgit2
+mkdir build
+cd build
+cmake -G "MinGW Makefiles" ..
+cmake --build .
+```
+
+Now you should have a `libgit2.dll` in the `build` directory. This should be copied to a location in your `PATH` or to the same directory as your Neovim executable.
+
 ### Neovim
 
 #### Lazy

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ If you are using lazy, you can use this config
 
 ```lua
 {
-  'SuperBo/fugit2.nvim'
+  'SuperBo/fugit2.nvim',
   opts = {},
   dependencies = {
     'MunifTanjim/nui.nvim',


### PR DESCRIPTION
Great plugin! Just got it up and running on my windows machine after scratching my head for a bit trying to get libgit2 set up.
I've added the steps I've used to the readme so it's a bit easier for others who might be in the same boat. 

Also fixed a missing comma in the example config - if you copy paste directly from the readme into a lazy config you get an error.