### PR TITLE
add diffview.nvim as an explicit dependency in lazy.nvim config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ If you are using lazy, you can use this config
   dependencies = {
     'MunifTanjim/nui.nvim',
     'nvim-tree/nvim-web-devicons',
+    'sindrets/diffview.nvim',
     'nvim-lua/plenary.nvim',
     {
       'chrisgrieser/nvim-tinygit', -- optional: for Github PR view


### PR DESCRIPTION
Trying to invoke diffview (`dd`) before diffview has been used will fail silently unless diffview is explicitly included in the deps for this plugin