### PR TITLE
feat: add FzfLua as branch view

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Git plugin for Neovim (based on libgit2).
 - ☐ TODO: Diff view.
 - ☐ TODO: Remap default key binding.
 - ☐ TODO: Proper help menu.
+- ☐ TODO: Native branch popup.
 
 ## 📦 Installation
 

--- a/lua/fugit2/view/git_status.lua
+++ b/lua/fugit2/view/git_status.lua
@@ -1687,8 +1687,11 @@ function GitStatus:_init_branch_menu()
       if vim.fn.exists ":Telescope" then
         self:unmount()
         vim.cmd { cmd = "Telescope", args = { "git_branches" } }
+      elseif vim.fn.exists ":FzfLua" then
+        self:unmount()
+        vim.cmd { cmd = "FzfLua", args = { "git_branches" } }
       else
-        vim.notify "[Fugit2] No telescope"
+        vim.notify "[Fugit2] No Telescope or FzfLua found!"
       end
     end
   end)


### PR DESCRIPTION
Add FzfLua as branch view. Current implementation use Telescope as backend for branch view, so we add FzfLua as other altenatives.

We need to implement this feature natively in Fugit2 without any dependencies.