### PR TITLE
chore: simplify install steps for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,30 +69,9 @@ brew install libgit2
 
 #### Windows
 
-There are no pre-packaged releases of libgit2 on Windows so the library must be built from source.
-
-##### Install CMake and MinGW (with Chocolatey)
-
 ```powershell
-#requires -RunAsAdministrator
-choco install cmake --installargs 'ADD_CMAKE_TO_PATH=User'
-choco install mingw
+choco install libgit2
 ```
-
-Make sure to restart your terminal after installing MinGW to ensure that the `gcc` and `g++` commands are available.
-
-##### Clone and build libgit2
-
-```powershell
-git clone https://github.com/libgit2/libgit2
-cd libgit2
-mkdir build
-cd build
-cmake -G "MinGW Makefiles" ..
-cmake --build .
-```
-
-Now you should have a `libgit2.dll` in the `build` directory. This should be copied to a location in your `PATH` or to the same directory as your Neovim executable.
 
 </details>
 


### PR DESCRIPTION
After my [last PR](https://github.com/SuperBo/fugit2.nvim/pull/16), I decided to package the [libgit2 library for Windows](https://github.com/scottmckendry/choco-libgit2) for two main reasons:

1. Building the library from source takes over 10 minutes (after you've got the required deps installed and cloned the repo)
2. I've never packaged anything before and thought it would be a good learning experience.

Two months later... and we have a verified package in the chocolatey repos:

https://community.chocolatey.org/packages/libgit2

This takes just a few seconds to install and works with fugit2 right out of the box. No need to move the dll anywhere around the filesystem or manually alter the PATH variable. 

This PR should make the installation process much easier for Windows users 🙂 

![image](https://c.tenor.com/olnkZI1dcQQAAAAC/tenor.gif)
