### PR TITLE
feat: allow setting libgit2 lib path

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,16 +43,58 @@ For more information, you can refer to this https://libgit2.org/
 
 ```sh
 sudo apt-get install -y libgit2-1.1
-sudo ln -s /usr/lib/x86_64-linux-gnu/libgit2.so.1.1 /usr/local/lib/libgit2.so
-sudo ldconfig
+# sudo ln -s /usr/lib/x86_64-linux-gnu/libgit2.so.1.1 /usr/local/lib/libgit2.so
+# sudo ldconfig
+```
+
+Set libgit2_path value in config options like this
+
+```lua
+{
+  'SuperBo/fugit2.nvim',
+  opts = {
+    libgit2_path = 'libgit2.so.1.1',
+  },
+  ...
+}
 ```
 
 #### Ubuntu 23.10
 
 ```sh
 sudo apt-get install -y libgit2-1.5
-sudo ln -s /usr/lib/x86_64-linux-gnu/libgit2.so.1.5 /usr/local/lib/libgit2.so
-sudo ldconfig
+# sudo ln -s /usr/lib/x86_64-linux-gnu/libgit2.so.1.5 /usr/local/lib/libgit2.so
+# sudo ldconfig
+```
+
+Set libgit2_path value in config options like this
+
+```lua
+{
+  'SuperBo/fugit2.nvim',
+  opts = {
+    libgit2_path = 'libgit2.so.1.5',
+  },
+  ...
+}
+```
+
+#### Ubuntu 24.04
+
+```sh
+sudo apt-get install -y libgit2-1.7
+```
+
+Set libgit2_path value in config options like this
+
+```lua
+{
+  'SuperBo/fugit2.nvim',
+  opts = {
+    libgit2_path = 'libgit2.so.1.7',
+  },
+  ...
+}
 ```
 
 #### Arch Linux
@@ -61,10 +103,39 @@ sudo ldconfig
 sudo pacman -S libgit2
 ```
 
+### Fedora
+
+```sh
+yum install libgit2
+```
+
+Set libgit2_path value in config options like this, change corresponding version.
+
+```lua
+{
+  'SuperBo/fugit2.nvim',
+  opts = {
+    libgit2_path = 'libgit2.so.1.7',
+  },
+  ...
+}
+```
+
 #### Mac OS
 
 ```sh
 brew install libgit2
+```
+
+Set libgit2_path value in config options like this if normal load doesn't work
+
+```lua
+{
+  'SuperBo/fugit2.nvim',
+  opts = {
+    libgit2_path = '/opt/homebrew/lib/libgit2.dylib',
+  },
+}
 ```
 
 #### Windows

--- a/lua/fugit2/init.lua
+++ b/lua/fugit2/init.lua
@@ -1,7 +1,6 @@
 -- Fugit2 main module file
 local colors = require "fugit2.view.colors"
-local git2 = require "fugit2.git2"
-local ui = require "fugit2.view.ui"
+local libgit2 = require "fugit2.libgit2"
 
 ---@class Fugit2Config
 ---@field width integer|string main popup width
@@ -9,6 +8,7 @@ local ui = require "fugit2.view.ui"
 ---@field min_width integer
 ---@field content_width integer
 ---@field height integer|string main file popup height
+---@field libgit2_path string? path to libgit2 lib if not set via environments
 local config = {
   width = 100,
   min_width = 50,
@@ -34,6 +34,9 @@ M.setup = function(args)
 
   -- Validate
 
+  -- Load C Library
+  libgit2.load_library(M.config.libgit2_path)
+
   if M.namespace == 0 then
     M.namespace = vim.api.nvim_create_namespace "Fugit2"
     colors.set_hl(0)
@@ -51,6 +54,8 @@ local function open_repository()
   local repo = repos[cwd]
 
   if not repo then
+    local git2 = require "fugit2.git2"
+
     local err
     repo, err = git2.Repository.open(cwd, true)
     if repo then
@@ -73,6 +78,7 @@ end
 function M.git_status()
   local repo = open_repository()
   if repo then
+    local ui = require "fugit2.view.ui"
     ui.new_fugit2_status_window(M.namespace, repo, M.config):mount()
   end
 end
@@ -80,6 +86,7 @@ end
 function M.git_graph()
   local repo = open_repository()
   if repo then
+    local ui = require "fugit2.view.ui"
     ui.new_fugit2_graph_window(M.namespace, repo):mount()
   end
 end
@@ -87,6 +94,7 @@ end
 function M.git_diff()
   local repo = open_repository()
   if repo then
+    local ui = require "fugit2.view.ui"
     ui.new_fugit2_diff_view(M.namespace, repo):mount()
   end
 end

--- a/lua/fugit2/libgit2.lua
+++ b/lua/fugit2/libgit2.lua
@@ -567,9 +567,12 @@ ffi.cdef [[
 
 ---@class Libgit2Module
 ---@field C ffi.namespace*
-local M = {
-  C = ffi.load "libgit2",
-}
+local M = {}
+
+---@param path string?
+M.load_library = function(path)
+  rawset(M, "C", ffi.load(path or "libgit2"))
+end
 
 M.uint32 = ffi.typeof "uint32_t"
 M.char_pointer = ffi.typeof "char*"


### PR DESCRIPTION
Libgit2 library name is depends on system, we can't assume that it will be "libgit2" on all the system. This MR enable capability to setting library name for each system.

Adding corresponding README.

This will resolve https://github.com/SuperBo/fugit2.nvim/issues/46