### PR TITLE
Fix ssh sign with literal key

### DIFF
--- a/lua/fugit2/utils.lua
+++ b/lua/fugit2/utils.lua
@@ -19,6 +19,9 @@ M.LINUX_SIGNALS = {
 ---@type string
 M.KEY_ESC = vim.api.nvim_replace_termcodes("<esc>", true, false, true)
 
+-- temp dir
+M.TMPDIR = os.getenv "TMPDIR" or "/tmp/"
+
 ---@param str string
 function M.lines_head(str)
   local newline = str:find("\n", 1, true)


### PR DESCRIPTION
when user provides `user.signingkey` as a literal ssh key, we need to save it to a tempfile then pass it to ssh-keygen instead.