### PR TITLE
fix(sign/gpg): keyid got overrided by signature

### DIFF
--- a/lua/fugit2/view/git_status.lua
+++ b/lua/fugit2/view/git_status.lua
@@ -817,7 +817,7 @@ function GitStatus:read_gpg_config()
   local keyid = config:get_string "user.signingkey" or nil
   local use_ssh = (config:get_string "gpg.format" == "ssh")
 
-  if not use_ssh and self._git.signature then
+  if not keyid and not use_ssh and self._git.signature then
     -- get committer info as key id
     keyid = tostring(self._git.signature)
   end


### PR DESCRIPTION
Cannot find the right key configured with ${user.signingkey}:

> [Fugit2] Failed to get gpg key ${user.name} <${user.email}>.
> Error code 16383

Fixes: 62040f7 ("feat: add ssh signing reword")