### PR TITLE
feat: add git worktree support

### DIFF
--- a/lua/fugit2/git2.lua
+++ b/lua/fugit2/git2.lua
@@ -2096,6 +2096,16 @@ function Repository:repo_path()
   return ffi.string(libgit2.C.git_repository_path(self.repo))
 end
 
+---Get the working directory path of this repository
+---@return string?
+function Repository:workdir()
+  local workdir = libgit2.C.git_repository_workdir(self.repo)
+  if workdir ~= nil then
+    return ffi.string(workdir)
+  end
+  return nil
+end
+
 ---Get the configuration file for this repository
 ---@return GitConfig?
 ---@return GIT_ERROR

--- a/lua/fugit2/libgit2.lua
+++ b/lua/fugit2/libgit2.lua
@@ -535,6 +535,7 @@ ffi.cdef [[
   int git_repository_open_ext(git_repository **out, const char *path, unsigned int flags, const char *ceiling_dirs);
   void git_repository_free(git_repository *repo);
   const char* git_repository_path(const git_repository *repo);
+  const char* git_repository_workdir(const git_repository *repo);
   int git_repository_is_empty(git_repository *repo);
   int git_repository_is_bare(const git_repository *repo);
   int git_repository_head_detached(git_repository *repo);

--- a/lua/fugit2/view/git_base_view.lua
+++ b/lua/fugit2/view/git_base_view.lua
@@ -27,7 +27,7 @@ function GitStatusDiffBase:init(ns_id, repo, index)
   end
 
   self._git = {
-    path = vim.fn.fnamemodify(repo:repo_path(), ":p:h:h"),
+    path = repo:workdir(),
     index_updated = false,
   }
 end

--- a/lua/fugit2/view/git_blame.lua
+++ b/lua/fugit2/view/git_blame.lua
@@ -32,7 +32,7 @@ function GitBlame:init(ns_id, repo, file_bufnr)
   self.file_bufnr = file_bufnr
 
   local file_path = Path:new(vim.fn.fnameescape(vim.api.nvim_buf_get_name(file_bufnr)))
-  local git_path = vim.fn.fnamemodify(repo:repo_path(), ":p:h:h")
+  local git_path = repo:workdir()
 
   self._git = {
     file_path = file_path:make_relative(git_path),

--- a/lua/fugit2/view/git_blame_file.lua
+++ b/lua/fugit2/view/git_blame_file.lua
@@ -33,7 +33,7 @@ function GitBlameFile:init(ns_id, repo, file_bufnr)
   self.file_bufnr = file_bufnr
 
   local file_path = Path:new(vim.fn.fnameescape(vim.api.nvim_buf_get_name(file_bufnr)))
-  local git_path = vim.fn.fnamemodify(repo:repo_path(), ":p:h:h")
+  local git_path = repo:workdir()
 
   self._git = {
     repo = repo,

--- a/spec/fugit2/core/blame_spec.lua
+++ b/spec/fugit2/core/blame_spec.lua
@@ -245,7 +245,7 @@ describe("find_intersect_hunk", function()
 @@ -62,8 +67,21 @@ function GitDiff:init(ns_id, repo, index, head_commit)__
    -- git info__
    self._git = {__
-     path = vim.fn.fnamemodify(repo:repo_path(), ":p:h:h"),__
+     path = repo:workdir(),__
 +    head_name = "head::",__
 +    head_tree = nil,__
    }__


### PR DESCRIPTION
Fixes git worktree support in fugit2.nvim. Previously, the plugin couldn't properly handle git worktrees due to incorrect assumptions about git directory and working directory relationships.

## Problem

- Git worktrees were not properly discovered or cached
- File operations (opening files with Enter) showed `.git` prefixed paths
- Blame functionality didn't work in worktrees
- Repository caching logic assumed git directory was always a parent of working directory


## Changes
- **Added `git_repository_workdir` libgit2 binding** - Exposes libgit2's working directory function
- **Added `Repository:workdir()` method** - Lua wrapper to get working directory path
- **Fixed repository caching logic** - Now uses working directory paths instead of git directory paths
- **Updated file path construction** - All views now use `workdir()` instead of `repo_path()`
